### PR TITLE
condition on publish to npm

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     environment: npm_preview
     # this is because run_attempt starts at 2 for outside contributors
-    if: ${{ (github.run_attempt != 1) && (github.run_attempt != 2 && github.event.pull_request.head.repo.owner.login != 'Laserfiche') }}
+    if: ${{ github.run_attempt != 1 }}
     needs: [ build ] # wait for build to finish
     steps:
       - uses: actions/checkout@v2
@@ -136,7 +136,7 @@ jobs:
   publish_to_npm_release:
     runs-on: ubuntu-latest
     environment: npm_production
-    if: ${{ (github.run_attempt != 1) && (github.run_attempt != 2 && github.event.pull_request.head.repo.owner.login != 'Laserfiche') }}
+    if: ${{ github.run_attempt != 1 }}
     needs: [ build ]
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
because we don't have to consider outside fork pull request, we are removing the condition that if action is from a fork pr, skip until run attemp 2